### PR TITLE
Improve close button styling across multiple components

### DIFF
--- a/src/components/popups/DownloadGame.tsx
+++ b/src/components/popups/DownloadGame.tsx
@@ -30,7 +30,7 @@ export default function DownloadGame({disk, setOpenPopup, displayName, settings,
         <div className="rounded-lg h-full w-3/4 flex flex-col p-4 gap-8 overflow-scroll scrollbar-none">
             <div className="flex flex-row items-center justify-between">
                 <h1 className="text-white text-stroke font-bold text-2xl">Download {displayName}</h1>
-                <X className="text-neutral-500 hover:text-neutral-700 cursor-pointer" onClick={() => setOpenPopup(POPUPS.NONE)}/>
+                <X className="text-white hover:text-gray-200 cursor-pointer drop-shadow-lg" style={{filter: 'drop-shadow(0 0 2px rgba(0,0,0,0.8))'}} onClick={() => setOpenPopup(POPUPS.NONE)}/>
             </div>
             <div className="flex flex-row-reverse">
                 <button className="flex flex-row gap-1 items-center p-2 bg-purple-600 hover:bg-purple-700 rounded-lg disabled:bg-gray-500" id={"game_dl_btn"} onClick={() => {

--- a/src/components/popups/DownloadGame.tsx
+++ b/src/components/popups/DownloadGame.tsx
@@ -30,7 +30,7 @@ export default function DownloadGame({disk, setOpenPopup, displayName, settings,
         <div className="rounded-lg h-full w-3/4 flex flex-col p-4 gap-8 overflow-scroll scrollbar-none">
             <div className="flex flex-row items-center justify-between">
                 <h1 className="text-white text-stroke font-bold text-2xl">Download {displayName}</h1>
-                <X className="text-white hover:text-gray-200 cursor-pointer drop-shadow-lg" style={{filter: 'drop-shadow(0 0 2px rgba(0,0,0,0.8))'}} onClick={() => setOpenPopup(POPUPS.NONE)}/>
+                <X className="text-white hover:text-gray-200 cursor-pointer drop-shadow-lg" onClick={() => setOpenPopup(POPUPS.NONE)}/>
             </div>
             <div className="flex flex-row-reverse">
                 <button className="flex flex-row gap-1 items-center p-2 bg-purple-600 hover:bg-purple-700 rounded-lg disabled:bg-gray-500" id={"game_dl_btn"} onClick={() => {

--- a/src/components/popups/repomanager/AddRepo.tsx
+++ b/src/components/popups/repomanager/AddRepo.tsx
@@ -13,7 +13,7 @@ export default function AddRepo({setOpenPopup}: {setOpenPopup: (popup: POPUPS) =
                 }}/>
                 <h1 className="text-white text-stroke font-bold text-2xl">Add a Repository</h1>
                 <div className="flex-grow">{/* Spacer */}</div>
-                <X className="text-neutral-500 hover:text-neutral-700 cursor-pointer" onClick={() => setOpenPopup(POPUPS.NONE)}/>
+                <X className="text-white hover:text-gray-200 cursor-pointer drop-shadow-lg" style={{filter: 'drop-shadow(0 0 2px rgba(0,0,0,0.8))'}} onClick={() => setOpenPopup(POPUPS.NONE)}/>
             </div>
 
             <div>{/* Spacer */}</div>

--- a/src/components/popups/repomanager/AddRepo.tsx
+++ b/src/components/popups/repomanager/AddRepo.tsx
@@ -13,7 +13,7 @@ export default function AddRepo({setOpenPopup}: {setOpenPopup: (popup: POPUPS) =
                 }}/>
                 <h1 className="text-white text-stroke font-bold text-2xl">Add a Repository</h1>
                 <div className="flex-grow">{/* Spacer */}</div>
-                <X className="text-white hover:text-gray-200 cursor-pointer drop-shadow-lg" style={{filter: 'drop-shadow(0 0 2px rgba(0,0,0,0.8))'}} onClick={() => setOpenPopup(POPUPS.NONE)}/>
+                <X className="text-white hover:text-gray-200 cursor-pointer drop-shadow-lg" onClick={() => setOpenPopup(POPUPS.NONE)}/>
             </div>
 
             <div>{/* Spacer */}</div>

--- a/src/components/popups/repomanager/RepoManager.tsx
+++ b/src/components/popups/repomanager/RepoManager.tsx
@@ -7,7 +7,7 @@ export default function RepoManager({repos, setOpenPopup, fetchRepositories}: {r
         <div className="rounded-lg h-full w-3/4 flex flex-col p-4 gap-8 overflow-scroll scrollbar-none">
             <div className="flex flex-row items-center justify-between">
                 <h1 className="text-white text-stroke font-bold text-2xl">Repositories and Manifests</h1>
-                <X className="text-white hover:text-gray-200 cursor-pointer drop-shadow-lg" style={{filter: 'drop-shadow(0 0 2px rgba(0,0,0,0.8))'}} onClick={() => setOpenPopup(POPUPS.NONE)}/>
+                <X className="text-white hover:text-gray-200 cursor-pointer drop-shadow-lg" onClick={() => setOpenPopup(POPUPS.NONE)}/>
             </div>
             <div className="flex-row-reverse hidden">
                 <button className="flex flex-row gap-1 items-center p-2 bg-blue-600 hover:bg-blue-700 rounded-lg" onClick={() => {setOpenPopup(POPUPS.ADDREPO)}}>

--- a/src/components/popups/repomanager/RepoManager.tsx
+++ b/src/components/popups/repomanager/RepoManager.tsx
@@ -7,7 +7,7 @@ export default function RepoManager({repos, setOpenPopup, fetchRepositories}: {r
         <div className="rounded-lg h-full w-3/4 flex flex-col p-4 gap-8 overflow-scroll scrollbar-none">
             <div className="flex flex-row items-center justify-between">
                 <h1 className="text-white text-stroke font-bold text-2xl">Repositories and Manifests</h1>
-                <X className="text-neutral-500 hover:text-neutral-700 cursor-pointer" onClick={() => setOpenPopup(POPUPS.NONE)}/>
+                <X className="text-white hover:text-gray-200 cursor-pointer drop-shadow-lg" style={{filter: 'drop-shadow(0 0 2px rgba(0,0,0,0.8))'}} onClick={() => setOpenPopup(POPUPS.NONE)}/>
             </div>
             <div className="flex-row-reverse hidden">
                 <button className="flex flex-row gap-1 items-center p-2 bg-blue-600 hover:bg-blue-700 rounded-lg" onClick={() => {setOpenPopup(POPUPS.ADDREPO)}}>

--- a/src/components/popups/settings/SettingsGlobal.tsx
+++ b/src/components/popups/settings/SettingsGlobal.tsx
@@ -11,7 +11,7 @@ export default function SettingsGlobal({setOpenPopup, settings, fetchSettings}: 
         <div className="rounded-lg h-full w-3/4 flex flex-col p-4 gap-8 overflow-scroll scrollbar-none">
                 <div className="flex flex-row items-center justify-between">
                     <h1 className="text-white text-stroke font-bold text-2xl">Settings</h1>
-                    <X className="text-neutral-500 hover:text-neutral-700 cursor-pointer" onClick={() => setOpenPopup(POPUPS.NONE)}/>
+                    <X className="text-white hover:text-gray-200 cursor-pointer drop-shadow-lg" style={{filter: 'drop-shadow(0 0 2px rgba(0,0,0,0.8))'}} onClick={() => setOpenPopup(POPUPS.NONE)}/>
                 </div>
             <div className="flex flex-row-reverse gap-1">
                 <button className="flex flex-row gap-1 items-center p-2 bg-purple-600 hover:bg-purple-700 rounded-lg" onClick={() => {

--- a/src/components/popups/settings/SettingsGlobal.tsx
+++ b/src/components/popups/settings/SettingsGlobal.tsx
@@ -11,7 +11,7 @@ export default function SettingsGlobal({setOpenPopup, settings, fetchSettings}: 
         <div className="rounded-lg h-full w-3/4 flex flex-col p-4 gap-8 overflow-scroll scrollbar-none">
                 <div className="flex flex-row items-center justify-between">
                     <h1 className="text-white text-stroke font-bold text-2xl">Settings</h1>
-                    <X className="text-white hover:text-gray-200 cursor-pointer drop-shadow-lg" style={{filter: 'drop-shadow(0 0 2px rgba(0,0,0,0.8))'}} onClick={() => setOpenPopup(POPUPS.NONE)}/>
+                    <X className="text-white hover:text-gray-200 cursor-pointer drop-shadow-lg" onClick={() => setOpenPopup(POPUPS.NONE)}/>
                 </div>
             <div className="flex flex-row-reverse gap-1">
                 <button className="flex flex-row gap-1 items-center p-2 bg-purple-600 hover:bg-purple-700 rounded-lg" onClick={() => {

--- a/src/components/popups/settings/SettingsInstall.tsx
+++ b/src/components/popups/settings/SettingsInstall.tsx
@@ -40,7 +40,7 @@ export default class SettingsInstall extends React.Component<IProps, IState> {
             <div className="rounded-lg h-full w-3/4 flex flex-col p-4 gap-8 overflow-scroll scrollbar-none">
                 <div className="flex flex-row items-center justify-between">
                     <h1 className="text-white text-stroke font-bold text-2xl">{this.props.installSettings.name}</h1>
-                    <X className="text-white hover:text-gray-200 cursor-pointer drop-shadow-lg" style={{filter: 'drop-shadow(0 0 2px rgba(0,0,0,0.8))'}} onClick={() => {
+                    <X className="text-white hover:text-gray-200 cursor-pointer drop-shadow-lg" onClick={() => {
                         this.props.setOpenPopup(POPUPS.NONE);
                         // @ts-ignore
                         document.getElementById(this.props.installSettings.id).focus();

--- a/src/components/popups/settings/SettingsInstall.tsx
+++ b/src/components/popups/settings/SettingsInstall.tsx
@@ -40,7 +40,7 @@ export default class SettingsInstall extends React.Component<IProps, IState> {
             <div className="rounded-lg h-full w-3/4 flex flex-col p-4 gap-8 overflow-scroll scrollbar-none">
                 <div className="flex flex-row items-center justify-between">
                     <h1 className="text-white text-stroke font-bold text-2xl">{this.props.installSettings.name}</h1>
-                    <X className="text-neutral-500 hover:text-neutral-700 cursor-pointer" onClick={() => {
+                    <X className="text-white hover:text-gray-200 cursor-pointer drop-shadow-lg" style={{filter: 'drop-shadow(0 0 2px rgba(0,0,0,0.8))'}} onClick={() => {
                         this.props.setOpenPopup(POPUPS.NONE);
                         // @ts-ignore
                         document.getElementById(this.props.installSettings.id).focus();


### PR DESCRIPTION
This pull request updates the styling of the close button (`X` component) across multiple popup components to improve visual consistency and accessibility. The changes primarily focus on updating the text color, hover effect, and adding a drop shadow.

### Styling improvements for close buttons:

* Updated the `X` component in `DownloadGame` to use white text with a hover effect transitioning to gray, and added a drop shadow for better visibility (`src/components/popups/DownloadGame.tsx`).
* Applied the same styling updates to the `X` component in `AddRepo` for consistency (`src/components/popups/repomanager/AddRepo.tsx`).
* Updated the `X` component in `RepoManager` with the new styling for uniformity across popups (`src/components/popups/repomanager/RepoManager.tsx`).
* Modified the `X` component in `SettingsGlobal` to match the updated styling with white text and a drop shadow (`src/components/popups/settings/SettingsGlobal.tsx`).
* Updated the `X` component in `SettingsInstall` to incorporate the new styling for consistency (`src/components/popups/settings/SettingsInstall.tsx`).