### PR TITLE
Fix tooltips

### DIFF
--- a/src/components/SidebarIconInstall.tsx
+++ b/src/components/SidebarIconInstall.tsx
@@ -1,4 +1,5 @@
 import React, {useRef, useState} from "react";
+import ReactDOM from "react-dom";
 import {
     arrow,
     autoUpdate,
@@ -58,12 +59,15 @@ export default function SidebarIconInstall({icon, name, id, setCurrentInstall, s
                     elem.focus();
                 }
             }} alt={"?"}/> : null}
-            {(enabled) ?
-                (isOpen && popup == POPUPS.NONE) && (
-                    <div ref={refs.setFloating} style={floatingStyles} {...getFloatingProps()} className="bg-black/75 rounded-md p-2 min-w-max z-50">
-                        <FloatingArrow ref={arrowRef} context={context} className="fill-black/75" />
-                        <span className="text-white z-50">{name}</span>
-                    </div>
+            {(enabled && isOpen && popup == POPUPS.NONE) ?
+                (typeof window !== "undefined" && window.document &&
+                    ReactDOM.createPortal(
+                        <div ref={refs.setFloating} style={floatingStyles} {...getFloatingProps()} className="bg-black/75 rounded-md p-2 min-w-max z-50">
+                            <FloatingArrow ref={arrowRef} context={context} className="fill-black/75" />
+                            <span className="text-white z-50">{name}</span>
+                        </div>,
+                        window.document.body
+                    )
                 ) : null}
         </React.Fragment>
     )

--- a/src/components/SidebarIconManifest.tsx
+++ b/src/components/SidebarIconManifest.tsx
@@ -1,4 +1,5 @@
 import React, {useRef, useState} from "react";
+import ReactDOM from "react-dom";
 import {
     arrow,
     autoUpdate,
@@ -56,12 +57,15 @@ export default function SidebarIconManifest({icon, name, id, setGameIcon, setCur
                 // @ts-ignore
                 document.getElementById(id).focus();
             }} alt={"?"}/> : null}
-            {(enabled) ?
-                (isOpen && popup == POPUPS.NONE) && (
-                    <div ref={refs.setFloating} style={floatingStyles} {...getFloatingProps()} className="bg-black/75 rounded-md p-2 min-w-max z-50">
-                        <FloatingArrow ref={arrowRef} context={context} className="fill-black/75" />
-                        <span className="text-white z-50">{name}</span>
-                    </div>
+            {(enabled && isOpen && popup == POPUPS.NONE) ?
+                (typeof window !== "undefined" && window.document &&
+                    ReactDOM.createPortal(
+                        <div ref={refs.setFloating} style={floatingStyles} {...getFloatingProps()} className="bg-black/75 rounded-md p-2 min-w-max z-50">
+                            <FloatingArrow ref={arrowRef} context={context} className="fill-black/75" />
+                            <span className="text-white z-50">{name}</span>
+                        </div>,
+                        window.document.body
+                    )
                 ) : null}
         </React.Fragment>
     )


### PR DESCRIPTION
This pull request updates how popups are rendered in the `SidebarIconInstall` and `SidebarIconManifest` components to improve compatibility and ensure popups display correctly in all environments. The main change is switching popup rendering to use React portals, which allows the popup elements to be rendered at the top level of the DOM (`document.body`) instead of within their parent components.

**Popup rendering improvements:**

* Added `ReactDOM` imports to both `SidebarIconInstall.tsx` and `SidebarIconManifest.tsx` to support portal rendering. [[1]](diffhunk://#diff-9bf11b1586f8a0157e3d1fffba12f12ea98ccaae01fef964a76c831247665c4cR2) [[2]](diffhunk://#diff-3be3e84cae53dee5165e57da57faec3c93a8d452d4e0fb765aedc782a02bc583R2)
* Changed the popup rendering logic in both components to use `ReactDOM.createPortal`, ensuring that popups are rendered into `window.document.body` only when the environment supports it. This fixes potential issues with popup positioning and z-index stacking. [[1]](diffhunk://#diff-9bf11b1586f8a0157e3d1fffba12f12ea98ccaae01fef964a76c831247665c4cL61-R70) [[2]](diffhunk://#diff-3be3e84cae53dee5165e57da57faec3c93a8d452d4e0fb765aedc782a02bc583L59-R68)