### PR TITLE
Fixes for UI Desync

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,7 @@ export default class App extends React.Component<any, any> {
         this.fetchSettings = this.fetchSettings.bind(this);
         this.fetchRepositories = this.fetchRepositories.bind(this);
         this.fetchInstallSettings = this.fetchInstallSettings.bind(this);
+        this.fetchInstallResumeStates = this.fetchInstallResumeStates.bind(this);
         this.fetchDownloadSizes = this.fetchDownloadSizes.bind(this);
         this.fetchGameVersions = this.fetchGameVersions.bind(this);
         this.fetchCompatibilityVersions = this.fetchCompatibilityVersions.bind(this);
@@ -314,6 +315,8 @@ export default class App extends React.Component<any, any> {
             completeInitialLoading: () => this.completeInitialLoading(),
             pushInstalls: this.pushInstalls,
             applyEventState: (ns) => this.setState(() => ({ ...ns })),
+            getCurrentInstall: () => this.state.currentInstall,
+            fetchInstallResumeStates: this.fetchInstallResumeStates,
         });
     }
 

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -1,6 +1,12 @@
 import { toPercent, formatBytes } from '../utils/progress.ts';
 
-export function registerEvents(eventType: string, event: any, pushInstalls: () => void) {
+export function registerEvents(
+  eventType: string, 
+  event: any, 
+  pushInstalls: () => void, 
+  getCurrentInstall: () => string, 
+  fetchInstallResumeStates: (install: string) => void
+) {
   switch (eventType) {
     case 'move_complete':
     case 'download_complete':
@@ -8,6 +14,13 @@ export function registerEvents(eventType: string, event: any, pushInstalls: () =
     case 'repair_complete':
     case 'preload_complete': {
       pushInstalls();
+      
+      // Refresh resume states for the current install after completion
+      const currentInstall = getCurrentInstall();
+      if (currentInstall) {
+        fetchInstallResumeStates(currentInstall);
+      }
+      
       return {
         hideProgressBar: true,
         disableInstallEdit: false,

--- a/src/services/loader.ts
+++ b/src/services/loader.ts
@@ -21,6 +21,8 @@ export interface LoaderOptions {
   // Event state wiring
   pushInstalls: () => void;
   applyEventState: (ns: Record<string, any>) => void;
+  getCurrentInstall: () => string;
+  fetchInstallResumeStates: (install: string) => void;
 }
 
 export interface LoaderController {
@@ -94,7 +96,7 @@ export function startInitialLoad(opts: LoaderOptions): LoaderController {
         for (const eventType of Events) {
           const unlisten = await listen(eventType, (event) => {
             if (cancelled) return;
-            const ns = registerEvents(eventType, event, opts.pushInstalls);
+            const ns = registerEvents(eventType, event, opts.pushInstalls, opts.getCurrentInstall, opts.fetchInstallResumeStates);
             if (ns !== undefined) opts.applyEventState(ns);
           });
           unlistenFns.push(unlisten);


### PR DESCRIPTION
This pull request enhances the application's event handling by ensuring that install resume states are refreshed after relevant install events complete. The main changes involve updating the event registration and loader wiring to support this new behavior.

**Event handling improvements:**

* The `registerEvents` function in `src/services/events.ts` now accepts `getCurrentInstall` and `fetchInstallResumeStates` as additional parameters, and after certain install completion events, it calls `fetchInstallResumeStates` for the current install to refresh its resume state.
* The `LoaderOptions` interface in `src/services/loader.ts` is updated to require the new `getCurrentInstall` and `fetchInstallResumeStates` callbacks, ensuring these are available for event handling.
* The `startInitialLoad` function in `src/services/loader.ts` is updated to pass the new callbacks to `registerEvents` for all event listeners.

**App component wiring:**

* In `src/App.tsx`, the `App` component now binds and provides `fetchInstallResumeStates` and `getCurrentInstall` methods to the loader options, making them available for event handling. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R43) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R318-R319)

This PR Should close #100 